### PR TITLE
implement `FromStr` for `concrete::PrefixLength`

### DIFF
--- a/src/any/addr.rs
+++ b/src/any/addr.rs
@@ -301,7 +301,7 @@ impl Arbitrary for Address {
 
 #[cfg(test)]
 mod tests {
-    use proptest::{arbitrary::any, proptest};
+    use proptest::proptest;
 
     use super::*;
     use crate::traits::Address as _;

--- a/src/concrete/addr/mod.rs
+++ b/src/concrete/addr/mod.rs
@@ -299,7 +299,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{traits::Address as _, Ipv4, Ipv6};
+    use crate::traits::Address as _;
 
     #[test]
     fn ipv4_broadcast_is_broadcast() {

--- a/src/concrete/prefix/len.rs
+++ b/src/concrete/prefix/len.rs
@@ -155,3 +155,44 @@ where
             .boxed()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod ipv4 {
+        use super::*;
+
+        #[test]
+        fn parse_valid() {
+            let input = "/8";
+            let length = input.parse::<PrefixLength<Ipv4>>().unwrap();
+            assert_eq!(length.as_ref(), &8);
+        }
+
+        #[test]
+        fn parse_invalid() {
+            let input = "/40";
+            let length = input.parse::<PrefixLength<Ipv4>>();
+            assert!(length.is_err_and(|err| err.kind() == Kind::PrefixLength));
+        }
+    }
+
+    mod ipv6 {
+        use super::*;
+
+        #[test]
+        fn parse_valid() {
+            let input = "/40";
+            let length = input.parse::<PrefixLength<Ipv6>>().unwrap();
+            assert_eq!(length.as_ref(), &40);
+        }
+
+        #[test]
+        fn parse_invalid() {
+            let input = "128";
+            let length = input.parse::<PrefixLength<Ipv6>>();
+            assert!(length.is_err_and(|err| err.kind() == Kind::ParserError));
+        }
+    }
+}

--- a/src/concrete/prefix/len.rs
+++ b/src/concrete/prefix/len.rs
@@ -1,5 +1,5 @@
-use core::fmt;
 use core::ops::Neg;
+use core::{fmt, str::FromStr};
 
 use super::impl_try_from_any;
 use crate::{
@@ -92,6 +92,14 @@ impl<A: Afi> traits::PrefixLength for PrefixLength<A> {
         } else {
             Err(err!(Kind::PrefixLength))
         }
+    }
+}
+
+impl<A: Afi> FromStr for PrefixLength<A> {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        A::Primitive::parse_length(s).and_then(Self::from_primitive)
     }
 }
 

--- a/src/concrete/prefix/set/ops.rs
+++ b/src/concrete/prefix/set/ops.rs
@@ -1,4 +1,4 @@
-use core::cmp::{Ordering, PartialEq, PartialOrd};
+use core::cmp::Ordering;
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Not, Sub};
 
 use num_traits::{One, Zero};

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -148,7 +148,7 @@ mod tests {
             let bytes = s.as_bytes();
             let tail = &mut self.buf[self.cursor..];
             if tail.len() < bytes.len() {
-                return Err(core::fmt::Error);
+                return Err(fmt::Error);
             }
             let target = &mut tail[..bytes.len()];
             target.copy_from_slice(bytes);

--- a/src/parser/ipv4.rs
+++ b/src/parser/ipv4.rs
@@ -12,6 +12,14 @@ pub(crate) fn parse_addr(input: &str) -> Result<u32, Error> {
 
 #[allow(clippy::inline_always)]
 #[inline(always)]
+pub(crate) fn parse_length(input: &str) -> Result<u8, Error> {
+    Parser::new(input)
+        .take_only(Parser::take_length)
+        .ok_or_else(|| err!(Kind::ParserError))
+}
+
+#[allow(clippy::inline_always)]
+#[inline(always)]
 pub(crate) fn parse_prefix(input: &str) -> Result<(u32, u8), Error> {
     Parser::new(input)
         .take_with_length(Parser::take_ipv4_octets)
@@ -31,6 +39,7 @@ pub(crate) fn parse_range(input: &str) -> Result<(u32, u8, u8, u8), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::ipv6::parse_length;
 
     #[test]
     fn parse_ipv4_addr() {
@@ -67,6 +76,13 @@ mod tests {
         let input = "192.0.2.0/24,25,26";
         let range = parse_range(input).unwrap();
         assert_eq!(range, (0xc000_0200, 24, 25, 26));
+    }
+
+    #[test]
+    fn prefix_len() {
+        let input = "/24";
+        let length = parse_length(input).unwrap();
+        assert_eq!(length, 24);
     }
 
     #[cfg(feature = "std")]

--- a/src/parser/ipv4.rs
+++ b/src/parser/ipv4.rs
@@ -39,7 +39,6 @@ pub(crate) fn parse_range(input: &str) -> Result<(u32, u8, u8, u8), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::ipv6::parse_length;
 
     #[test]
     fn parse_ipv4_addr() {

--- a/src/parser/ipv6.rs
+++ b/src/parser/ipv6.rs
@@ -15,6 +15,14 @@ pub(crate) fn parse_addr(input: &str) -> Result<u128, Error> {
 
 #[allow(clippy::inline_always)]
 #[inline(always)]
+pub(crate) fn parse_length(input: &str) -> Result<u8, Error> {
+    Parser::new(input)
+        .take_only(Parser::take_length)
+        .ok_or_else(|| err!(Kind::ParserError))
+}
+
+#[allow(clippy::inline_always)]
+#[inline(always)]
 pub(crate) fn parse_prefix(input: &str) -> Result<(u128, u8), Error> {
     Parser::new(input)
         .take_with_length(Parser::take_ipv6_segments)
@@ -134,6 +142,13 @@ mod tests {
             range,
             (0x2001_0db8_0000_0000_0000_0000_0000_0000, 32, 48, 64)
         );
+    }
+
+    #[test]
+    fn prefix_len() {
+        let input = "/48";
+        let length = parse_length(input).unwrap();
+        assert_eq!(length, 48);
     }
 
     #[cfg(feature = "std")]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,7 +5,6 @@ trait Number: Eq + Sized {
     const ZERO: Self;
     fn checked_add(self, rhs: u8) -> Option<Self>;
     fn checked_mul(self, rhs: u8) -> Option<Self>;
-    fn to_be_bytes<const N: usize>(self) -> [u8; N];
 }
 
 macro_rules! impl_number {
@@ -18,11 +17,6 @@ macro_rules! impl_number {
                 }
                 fn checked_mul(self, rhs: u8) -> Option<Self> {
                     self.checked_mul(rhs.into())
-                }
-                fn to_be_bytes<const N: usize>(self) -> [u8; N] {
-                    let mut buf = [0; N];
-                    self.to_be_bytes().into_iter().enumerate().for_each(|(i, octet)| buf[i] = octet);
-                    buf
                 }
             }
         )*

--- a/src/traits/af.rs
+++ b/src/traits/af.rs
@@ -1,4 +1,3 @@
-use core::cmp::Ord;
 use core::fmt::Debug;
 use core::hash::Hash;
 

--- a/src/traits/primitive.rs
+++ b/src/traits/primitive.rs
@@ -462,7 +462,7 @@ pub(crate) trait IntoIpv6Segments: Address<Ipv6> {
         // Safety:
         // it is always safe to transmute `[u16; 8]` to `[u8; 16]`
         let octets = unsafe {
-            core::mem::transmute([
+            mem::transmute([
                 segments[0].to_be(),
                 segments[1].to_be(),
                 segments[2].to_be(),

--- a/src/traits/primitive.rs
+++ b/src/traits/primitive.rs
@@ -133,6 +133,20 @@ pub trait Address<A: Afi>:
     where
         S: AsRef<str> + ?Sized;
 
+    /// Parse a string into [`Self::Length`].
+    ///
+    /// This method is primarily intended for use via the
+    /// [`FromStr`][core::str::FromStr] implementation for
+    /// [`PrefixLength<A>`][crate::PrefixLength].
+    ///
+    /// # Errors
+    ///
+    /// Fails if the string does not conform to the textual address
+    /// representation rules for `A`.
+    fn parse_length<S>(s: &S) -> Result<Self::Length, Error>
+    where
+        S: AsRef<str> + ?Sized;
+
     /// Parse a string into a `(Self, Self::Length>)`
     /// pair.
     ///
@@ -283,6 +297,13 @@ impl Address<Ipv4> for u32 {
         parser::ipv4::parse_addr(s.as_ref())
     }
 
+    fn parse_length<S>(s: &S) -> Result<Self::Length, Error>
+    where
+        S: AsRef<str> + ?Sized,
+    {
+        parser::ipv4::parse_length(s.as_ref())
+    }
+
     fn parse_prefix<S>(s: &S) -> Result<(Self, Self::Length), Error>
     where
         S: AsRef<str> + ?Sized,
@@ -388,6 +409,13 @@ impl Address<Ipv6> for u128 {
         S: AsRef<str> + ?Sized,
     {
         parser::ipv6::parse_addr(s.as_ref())
+    }
+
+    fn parse_length<S>(s: &S) -> Result<Self::Length, Error>
+    where
+        S: AsRef<str> + ?Sized,
+    {
+        parser::ipv6::parse_length(s.as_ref())
     }
 
     fn parse_prefix<S>(s: &S) -> Result<(Self, Self::Length), Error>

--- a/tests/prefix-set-proptests.rs
+++ b/tests/prefix-set-proptests.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::iter::FromIterator;
 
 use ip::{traits::PrefixSet as _, AfiClass, Any, Ipv4, Ipv6, Prefix, PrefixSet};
 use itertools::Itertools;


### PR DESCRIPTION
- implement `FromStr` for `concrete::PrefixLength`
- remove unused trait method `Number::to_be_bytes`
